### PR TITLE
Now Page Timeline Center Fix

### DIFF
--- a/pages/home/pages/now/OkNowPage.vue
+++ b/pages/home/pages/now/OkNowPage.vue
@@ -45,7 +45,7 @@
                             <ok-timeline-page
                                 class=""
                                 ref=timelinePostsStream
-                                post-container-class="has-padding-bottom-30-tablet has-padding-left-30-tablet"
+                                post-container-class="has-padding-bottom-30-tablet has-padding-right-30-tablet has-padding-left-30-tablet"
                             ></ok-timeline-page>
                         </b-tab-item>
                         <b-tab-item>

--- a/pages/home/pages/timeline/OkTimelinePage.vue
+++ b/pages/home/pages/timeline/OkTimelinePage.vue
@@ -5,7 +5,7 @@
                 :posts-display-context="postDisplayContext"
                 :refresher="postsRefresher"
                 :on-scroll-loader="postsOnScrollLoader"
-                post-container-class="has-padding-bottom-30-tablet has-padding-left-30-tablet"
+                :post-container-class="postContainerClass"
         >
             <template v-slot:leading>
                 <div class="has-padding-bottom-30-tablet has-padding-right-30-tablet has-padding-left-30-tablet">
@@ -19,7 +19,7 @@
 </template>
 
 <script lang="ts">
-    import { Component, Vue, Watch } from "nuxt-property-decorator"
+    import { Component, Prop, Vue, Watch } from "nuxt-property-decorator"
     import { Route } from "vue-router";
     import { IUserService } from "~/services/user/IUserService";
     import { TYPES } from "~/services/inversify-types";
@@ -49,6 +49,12 @@
         $observables!: {
             loggedInUser: BehaviorSubject<IUser | undefined>
         };
+
+        @Prop({
+            type: String,
+            required: false,
+            default: ""
+        }) readonly postContainerClass: string;
 
         $refs: {
             postsStream: OkPostsStream


### PR DESCRIPTION
This fixes the css classes so that the timeline tab on the now page is more consistent with the other tabs, including properly centering the stream on the page.

Before:
![image](https://github.com/user-attachments/assets/0a7b015e-188b-4226-87ab-f8cea38a5a4b)

After:
![image](https://github.com/user-attachments/assets/cacb088d-8a74-4ae7-af79-90bfac2a23d7)
