### PR TITLE
Now Page Sidebar: Minor tweaks so that when minimized, width is auto instead of 5%

### DIFF
--- a/pages/home/pages/now/OkNowPage.vue
+++ b/pages/home/pages/now/OkNowPage.vue
@@ -31,7 +31,7 @@
                   <component :is="isMinimized ? 'ok-plus-icon' : 'ok-close-icon'"></component>
                 </button>
                 <span class="ok-has-text-primary-invert">
-                  <p v-if="!isMinimized" class="p-4 mt-4 ok-has-text-primary-invert-80">
+                  <p v-if="!isMinimized" class="p-4 mt-4 ok-has-text-primary-invert-80" style="padding-bottom: 0px;">
                     {{$t('global.snippets.my_joined_communities')}}
                   </p>
                   <div class="joined-communities">
@@ -220,7 +220,7 @@
     }
 
     .ok-left-section.minimized {
-      width: 5%;
+      width: auto;
     }
 
     .toggle-btn {


### PR DESCRIPTION
Just a couple of minor tweaks for the new Now Page Sidebar: 
* When sidebar is minimized, width is auto instead of 5% to fit the contents.
* The paragraph when sidebar is not minimized has no bottom padding.

Here's how they look:
![image](https://github.com/user-attachments/assets/fdf27224-54e3-4ee9-b3a4-b005e1e939c2)

![image](https://github.com/user-attachments/assets/df0601c0-83d0-45a3-8240-0eb9da29c76e)
